### PR TITLE
Add support for asserting side effects

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
           run: dotnet build --no-restore src/Acumen.sln
           
         - name: Test
-          run: dotnet test --no-build --verbosity normal src/Acumen.Tests/Acument.Tests.csproj
+          run: dotnet test --no-build --verbosity normal src/Acumen.Tests/Acumen.Tests.csproj

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,31 @@
+# Build workflow for GitHub actions
+
+name: Build & test
+
+on:
+    push:
+        branches: [ "main" ]
+    pull_request:
+        branches: [ "main" ]
+
+jobs:
+    build:
+    
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v3
+  
+        - name: Setup .NET
+          uses: actions/setup-dotnet@v3
+          with:
+            dotnet-version: '8.0.x'
+
+        - name: Restore packages
+          run: dotnet restore src/Acumen.sln
+
+        - name: Build
+          run: dotnet build --no-restore src/Acumen.sln
+          
+        - name: Test
+          run: dotnet test --no-build --verbosity normal src/Acumen.sln

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -28,4 +28,4 @@ jobs:
           run: dotnet build --no-restore src/Acumen.sln
           
         - name: Test
-          run: dotnet test --no-build --verbosity normal src/Acumen.sln
+          run: dotnet test --no-build --verbosity normal src/Acumen.Tests/Acument.Tests.csproj

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,29 @@
+# Publish workflow for GitHub actions
+
+name: Publish package
+
+on:
+    workflow_run:
+        workflows: ["Build & test"]
+        branches: [ "main" ]
+        types:
+        - completed
+
+jobs:
+    publish:
+    
+        runs-on: ubuntu-latest
+
+        steps:
+        - uses: actions/checkout@v3
+  
+        - name: Setup .NET
+          uses: actions/setup-dotnet@v3
+          with:
+            dotnet-version: '8.0.x'
+
+        - name: Pack
+          run: dotnet pack -p:PackageId="${{ vars.NUGETPACKID }}" -p:Description="${{ vars.NUGETPACKDESCRIPTION }}" -p:Authors="${{ vars.NUGETPACKAUTHORS }}" -p:Copyright="${{ vars.NUGETPACKCOPYRIGHT }}" -p:PackageProjectUrl="${{ vars.NUGETPACKPROJECTURL }}" -c Release src/Acumen/
+
+        - name: Push
+          run: dotnet nuget push src/Acumen/bin/Release/Acumen.*.nupkg -k ${{ secrets.NUGETAPIKEY }} -s ${{ vars.NUGETPUSHSOURCE }} --skip-duplicate

--- a/src/Acumen.Tests/Acumen.Tests.csproj
+++ b/src/Acumen.Tests/Acumen.Tests.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,13 +11,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="xunit" Version="2.8.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.2.0">
+    <PackageReference Include="coverlet.collector" Version="6.0.2">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/src/Acumen/Acumen.csproj
+++ b/src/Acumen/Acumen.csproj
@@ -1,16 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>0.7.0</Version>
+    <Version>0.9.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CompareNETObjects" Version="4.79.0" />
-    <PackageReference Include="Microsoft.Reactive.Testing" Version="5.0.0" />
-    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="CompareNETObjects" Version="4.83.0" />
+    <PackageReference Include="Microsoft.Reactive.Testing" Version="6.0.1" />
+    <PackageReference Include="xunit" Version="2.8.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Acumen/Acumen.csproj
+++ b/src/Acumen/Acumen.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <Version>0.9.0</Version>
+	<GenerateDocumentationFile>True</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Acumen/Extensions/ExtensionsForImmutableStack.cs
+++ b/src/Acumen/Extensions/ExtensionsForImmutableStack.cs
@@ -10,9 +10,8 @@ static class ExtensionsForImmutableStack {
     /// <param name="stack">The stack to attempt to peek.</param>
     /// <param name="value">The value on top of the stack, if the peek was successful.</param>
     /// <returns><c>true</c> if the stack was successfully peeked, otherwise <c>false</c>.</returns>
-    public static bool TryPeek<T>(this ImmutableStack<T> stack, out T value) {
-        var isEmpty = stack?.IsEmpty ?? true;
-        value = isEmpty ? default(T) : stack.Peek();
-        return !isEmpty;
+    public static bool TryPeek<T>(this ImmutableStack<T> stack, out T? value) {
+        value = stack.IsEmpty ? default : stack.Peek();
+        return !stack.IsEmpty;
     }
 }

--- a/src/Acumen/Operators.cs
+++ b/src/Acumen/Operators.cs
@@ -32,7 +32,8 @@ public static class Operators {
     /// <exception cref="AssertionException">Thrown when the asserted observable does not match the expected marble diagram.</exception>
     public static void ExpectObservable<T>(IObservable<T> observable, MarbleDiagram<T> toBe) {
         TestSchedulerScope.Current.ScheduleAssertion(scheduler => {
-            Recorded<Notification<T>>[]  expectedNotifications = toBe;
+            Recorded<Notification<T>>[] expectedNotifications = toBe;
+            Recorded<Action>[] expectedSideEffects = toBe;
             
             var end = expectedNotifications.Last().Time + 1000;
             
@@ -47,6 +48,11 @@ public static class Operators {
             for (var i = 0; i < observer.Messages.Count; i++) {
                 if (!comparer.Equals(observer.Messages[i], expectedNotifications[i]))
                     throw new AssertionException(string.Format(OperatorResources.NotificationInequality, i + 1, expectedNotifications[i], observer.Messages[i]));
+            }
+
+            // run the side effect assertions
+            foreach (var expectedSideEffect in expectedSideEffects) {
+                expectedSideEffect.Value();
             }
         });
     }


### PR DESCRIPTION
Side effects are expressed in the marble diagram with a bang (!).

E.g. diagram: `---a--b--c!--d--|`

`a`, `b` and `d` are normal notifications. `c` is a side effect and we'd tie it to an `Action` delegate to perform the assertion. I like to use FakeItEasy, so my code would look like this:

```
var observable = ...;

ExpectObservable(observable, toBe: ("--a--b!--", new {
  a = 1,
  b = new Action(() => A.CallTo(() => _myService.DoSomething(...)).MustHaveHappened())
});
```

But you can do anything, really. The point is that you now get a way of describing side effects in the marble diagram, and that the assertion will be done after the observable was enumerator. Note that no time assertions occur.